### PR TITLE
Remove broken font link

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <title>Patchwork Download</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" media="screen" href="https://fontlibrary.org/face/source-code-pro" type="text/css" />
     <link href="index.css" rel="stylesheet" type="text/css" media="screen" charset="utf-8" />
   </head>
   <body>


### PR DESCRIPTION
Remove font link to
https://fontlibrary.org/face/source-code-pro
Because that url is broken and it holds up page rendering.